### PR TITLE
Task3

### DIFF
--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,12 +1,57 @@
+import { eq, ilike, and, or, sql } from "drizzle-orm";
 import db from "../../../db";
 import { advocates } from "../../../db/schema";
-import { advocateData } from "../../../db/seed/advocates";
+import { NextRequest, NextResponse } from "next/server";
 
-export async function GET() {
-  // Uncomment this line to use a database
-  // const data = await db.select().from(advocates);
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const page = parseInt(searchParams.get("page") || "1");
+    const searchTerm = searchParams.get("searchTerm")?.trim() || "";
+    const selectedCity = searchParams.get("selectedCity");
+    const selectedSpecialty = searchParams.get("selectedSpecialty");
+    const itemsPerPage = 6;
+    const offset = (page - 1) * itemsPerPage;
+    const filters = [];
 
-  const data = advocateData;
+    if (searchTerm) {
+      filters.push(
+        or(
+          ilike(advocates.firstName, `%${searchTerm}%`),
+          ilike(advocates.lastName, `%${searchTerm}%`),
+          ilike(advocates.city, `%${searchTerm}%`),
+          sql`${advocates.specialties}::text ILIKE ${`%${searchTerm}%`}`
+        )
+      );
+    }
 
-  return Response.json({ data });
+    if (selectedCity && selectedCity !== "All") {
+      filters.push(eq(advocates.city, selectedCity));
+    }
+
+    if (selectedSpecialty && selectedSpecialty !== "All") {
+      filters.push(
+        sql`${advocates.specialties}::text ILIKE ${`%${selectedSpecialty}%`}`
+      );
+    }
+
+    const whereClause = filters.length ? and(...filters) : undefined;
+
+    const data = await db
+      .select()
+      .from(advocates)
+      .where(whereClause)
+      .limit(itemsPerPage)
+      .offset(offset);
+
+    const [{ count }] = await db
+      .select({ count: sql<number>`COUNT(*)` })
+      .from(advocates)
+      .where(whereClause);
+
+    return NextResponse.json({ data, total: count });
+  } catch (err) {
+    console.error("Error in /api/advocates GET:", err);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -39,11 +39,7 @@ export default function Home() {
     fetch(`/api/advocates?${queryParams.toString()}`)
       .then((res) => res.json())
       .then((json) => {
-        if (page === 1) {
-          setFilteredAdvocates(json.data);
-        } else {
-          setFilteredAdvocates((prevData) => [...prevData, ...json.data]);
-        }
+        setFilteredAdvocates(json.data);
         setAdvocates(json.data);
         setTotalAdvocates(json.total);
         setLoading(false);
@@ -53,6 +49,10 @@ export default function Home() {
         setLoading(false);
       });
   }, [page, searchTerm, selectedCity, selectedSpecialty]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [searchTerm, selectedCity, selectedSpecialty]);
 
   const cities = useMemo(() => {
     if (!Array.isArray(advocates)) return ["All"];
@@ -84,11 +84,6 @@ export default function Home() {
       }, 500),
     []
   );
-
-  const paginatedAdvocates = useMemo(() => {
-    const start = (page - 1) * ITEMS_PER_PAGE;
-    return (filteredAdvocates || []).slice(start, start + ITEMS_PER_PAGE);
-  }, [filteredAdvocates, page]);
 
   const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value;
@@ -155,7 +150,7 @@ export default function Home() {
                 </tr>
               </thead>
               <tbody>
-                {paginatedAdvocates.map((advocate) => (
+                {filteredAdvocates.map((advocate) => (
                   <tr key={advocate.id} className="border-t hover:bg-gray-50">
                     <td className="px-4 py-2">{advocate.firstName}</td>
                     <td className="px-4 py-2">{advocate.lastName}</td>

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,20 +1,12 @@
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
+import * as schema from "./schema";
 
-const setup = () => {
-  if (!process.env.DATABASE_URL) {
-    console.error("DATABASE_URL is not set");
-    return {
-      select: () => ({
-        from: () => [],
-      }),
-    };
-  }
+if (!process.env.DATABASE_URL) {
+  throw new Error("DATABASE_URL is not set in environment variables");
+}
 
-  // for query purposes
-  const queryClient = postgres(process.env.DATABASE_URL);
-  const db = drizzle(queryClient);
-  return db;
-};
+const queryClient = postgres(process.env.DATABASE_URL, { max: 1 });
+const db = drizzle(queryClient, { schema });
 
-export default setup();
+export default db;


### PR DESCRIPTION
Consider both frontend and backend performance improvements. Assume we have a database of hundreds of thousands of advocates we need to search through.

With a large dataset (hundreds of thousands of advocates), both frontend and backend must be optimized to avoid performance bottlenecks.

Backend Improvements

> Implement Server-Side Filtering, Pagination, and Search
> Right now, it fetches the entire dataset and filters on the client, which doesn’t scale. So I changed the GET endpoint of the backend.

Frontend Improvements

> Fetch With Query Params - Update useEffect to fetch with filters
> Replace useMemo pagination
> Since it’s now paginating on the server, remove useMemo for slicing and use the paginated result from API directly.
> Client-Side Debouncing (already implemented)
> I’m using lodash.debounce, which is great. Just ensure searchTerm input updates local state and triggers the fetch.
